### PR TITLE
Naturalidad y concordancia

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -1,4 +1,5 @@
 var word1, word2;
+var sufijos_femeninos, sufijos_verbos;
 var lado;
 // Ñapa, debería tener en cuenta el JSON definido...
 if ( !location.search || location.search.match(/izq/) ){
@@ -11,6 +12,8 @@ $(document).ready(function() {
     $.getJSON("words.json", function( data ) {
 	word1 = data[lado][0];
 	word2 = data[lado][1];
+	sufijos_femeninos = data["sufijos_femeninos"];
+	sufijos_verbos = data["sufijos_verbos"];
     });
 
     $("#generate").click(function(){
@@ -33,12 +36,30 @@ $(document).ready(function() {
     });
 });
 
+function test_sufijos(word, sufijos) {
+	for (var s in sufijos)
+		if (word.substring(word.length-sufijos[s].length) == sufijos[s])
+			return true;
+	
+	return false;
+}
+
+ function femenino(word) {
+	return test_sufijos(word, sufijos_femeninos);
+ }
  
+ function verbo(word) {
+	return test_sufijos(word, sufijos_verbos);
+ }
  
 function generate(){
-    var firstWord = word1[Math.floor(Math.random()*word1.length)];
-    var secondWord = word2[Math.floor(Math.random()*word2.length)];
-    
+	var firstWord = word1[Math.floor(Math.random()*word1.length)];
+	var primera_verbo = verbo(firstWord);
+	var primera_femenino = femenino(firstWord);
+	do {
+		var secondWord = word2[Math.floor(Math.random()*word2.length)].replace(/@/g, (primera_femenino ? "a" : "o")).replace(/_/g, (primera_femenino ? "a" : ""));
+	} while (primera_verbo && verbo(secondWord));
+		
     var partido = firstWord + " " + secondWord;
     
     document.getElementById("partido").innerHTML = partido;

--- a/words.json
+++ b/words.json
@@ -2,7 +2,7 @@
  [
      ["Ahora", "En común", "Podemos", "Unidos", "Venceremos", "A la Moncloa", "Juntos, ", "Ganemos", "Al frente", "Unidad", "Adelante", "Vamos", "Convergencia", "Unión del pueblo", "Participa", "Acuerdo", "Ganar"],
      ["la izquierda", "juntos", "sí se puede", "por la democracia", "sí que se puede", "por los trabajadores", "es posible",
-      "en común", "toma la palabra", "por el pueblo", "por la dignidad", "por el cambio", "decide"]
+      "en común", "toma la palabra", "por el pueblo", "por la dignidad", "por el cambio", "decide", "podemos"]
  ],
 
  "derechas":

--- a/words.json
+++ b/words.json
@@ -7,7 +7,10 @@
 
  "derechas":
  [
-     ["Frente","Unión","Comunión", "Fuerza", "Libertad" ],
-     ["y Patria","por la Patria","y Orden","por la Justicia","y Democracia","de los Patriotas"]
- ]
+     ["Frente","Unión","Comunión","Fuerza","Libertad","Tradición","Unidad","Renovación","Alianza","Movimiento","Plataforma","Solidaridad"],
+     ["y Patria","por la Patria","y Orden","por la Justicia","y Democracia","de los Patriotas","Español_","Católic@","Liberal","Cristian@"]
+ ],
+ 
+ "sufijos_femeninos":   ["a", "ión", "ad"],
+ "sufijos_verbos":      ["emos", "amos", "se puede", "es posible"]
 }

--- a/words.json
+++ b/words.json
@@ -1,14 +1,14 @@
 {"izquierdas":
  [
-     ["Ahora", "En común", "Podemos", "Unidos", "Venceremos", "A la Moncloa", "Juntos, ", "Ganemos", "Al frente", "Unidad", "Adelante", "Vamos", "Convergencia", "Unión del pueblo", "Participa", "Acuerdo", "Ganar"],
+     ["Ahora", "En común", "Podemos", "Unidos", "Venceremos", "A la Moncloa", "Juntos, ", "Ganemos", "Al frente", "Unidad", "Adelante", "Vamos", "Convergencia", "Unión del pueblo", "Participa", "Acuerdo", "Ganar", "Decide", "Entre todos"],
      ["la izquierda", "juntos", "sí se puede", "por la democracia", "sí que se puede", "por los trabajadores", "es posible",
       "en común", "toma la palabra", "por el pueblo", "por la dignidad", "por el cambio", "decide", "podemos"]
  ],
 
  "derechas":
  [
-     ["Frente","Unión","Comunión","Fuerza","Libertad","Tradición","Unidad","Renovación","Alianza","Movimiento","Plataforma","Solidaridad"],
-     ["y Patria","por la Patria","y Orden","por la Justicia","y Democracia","de los Patriotas","Español_","Católic@","Liberal","Cristian@","Nacional"]
+     ["Frente","Unión","Comunión","Fuerza","Libertad","Tradición","Unidad","Renovación","Alianza","Movimiento","Plataforma","Solidaridad","Acción","Alternativa"],
+     ["y Patria","por la Patria","y Orden","por la Justicia","y Democracia","de los Patriotas","Español_","Católic@","Liberal","Cristian@","Nacional","Auténtic@"]
  ],
  
  "sufijos_femeninos":   ["a", "ión", "ad"],

--- a/words.json
+++ b/words.json
@@ -1,16 +1,16 @@
 {"izquierdas":
  [
-     ["Ahora", "En común", "Podemos", "Unidos", "Venceremos", "A la Moncloa", "Juntos, ", "Ganemos", "Al frente", "Unidad", "Adelante", "Vamos", "Convergencia", "Unión del pueblo" ],
+     ["Ahora", "En común", "Podemos", "Unidos", "Venceremos", "A la Moncloa", "Juntos, ", "Ganemos", "Al frente", "Unidad", "Adelante", "Vamos", "Convergencia", "Unión del pueblo", "Participa", "Acuerdo", "Ganar"],
      ["la izquierda", "juntos", "sí se puede", "por la democracia", "sí que se puede", "por los trabajadores", "es posible",
-      "en común", "toma la palabra", "por el pueblo", "por la dignidad", "por el cambio" ]
+      "en común", "toma la palabra", "por el pueblo", "por la dignidad", "por el cambio", "decide"]
  ],
 
  "derechas":
  [
      ["Frente","Unión","Comunión","Fuerza","Libertad","Tradición","Unidad","Renovación","Alianza","Movimiento","Plataforma","Solidaridad"],
-     ["y Patria","por la Patria","y Orden","por la Justicia","y Democracia","de los Patriotas","Español_","Católic@","Liberal","Cristian@"]
+     ["y Patria","por la Patria","y Orden","por la Justicia","y Democracia","de los Patriotas","Español_","Católic@","Liberal","Cristian@","Nacional"]
  ],
  
  "sufijos_femeninos":   ["a", "ión", "ad"],
- "sufijos_verbos":      ["emos", "amos", "se puede", "es posible"]
+ "sufijos_verbos":      ["ar", "emos", "amos", "se puede", "es posible", "cipa", "ide"]
 }


### PR DESCRIPTION
~~El título me ha quedado tipo partido de derechas.~~

Sugiero, para que se obtengan unos resultados más naturales, una serie de cambios que:
- Evitan que sea posible obtener un partido con más de un verbo, lo cual resulta muy artificial. Por ejemplo, _Podemos sí se puede_, _Venceremos es posible_ o _Ganemos sí que se puede_ serían resultados no posibles.
- Hacen posible la concordancia de género. Si en un segundo término se incluye el caracter `@`, será sustituido por `o` o por `a` según el término anterior requiera que sea masculino o femenino, mientras que `_` sería reemplazado por nada o por `a` en los mismos casos. Por ejemplo, si se obtiene _Frente_ y _Católic@_, el resultado será _Frente Católico_, pero si la primera palabra es _Unidad_, se devolverá _Unidad Católica_.

Ambas cosas se consiguen mediante sufijos. Además, se incluyen más términos en el JSON, aprovechando especialmente la versatilidad que ofrece el segundo punto en partidos de derechas.
